### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ arch-home      UUID=<uuid>    /secure/home_keyfile.bin
 Reload linux
 
 ```
-$ mkinitcpio -l linux
+$ mkinitcpio -p linux
 ```
 
 ## Grub


### PR DESCRIPTION
The command [ mkinitcpio -l linux ] will fail, unknown option [-l], the correct one (even according to the video is): mkinitcpio -p linux