### PR TITLE
Fix failure on creating initramfs when installing the lvm2 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ add `encrypt` and `lvm2` into the hooks
 HOOKS=(... block encrypt lvm2 filesystems fsck)
 ```
 
-install lvm2
+install lvm2 and main interface for btrfs filesystem operations
 
 ```
-$ pacman -S lvm2
+$ pacman -S lvm2 btrfs-progs
 ```
 
 ### Bootloader


### PR DESCRIPTION
Install the package btrfs-progs alongside with lvm2, that provides administration tools for btrfs, such as mkfs.btrfs, fsck.btrfs, btrfs-convert, etc.